### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+[![Board Status](https://dev.azure.com/carlosgutierrez0156/26e6c045-41d7-42a2-a3c9-9f614f728398/7f02b1ce-03e9-4cff-8f92-a488b0eff6f0/_apis/work/boardbadge/67f0a6c0-ee78-40fc-8976-5e863a39c018)](https://dev.azure.com/carlosgutierrez0156/26e6c045-41d7-42a2-a3c9-9f614f728398/_boards/board/t/7f02b1ce-03e9-4cff-8f92-a488b0eff6f0/Microsoft.RequirementCategory)


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/carlosgutierrez0156/26e6c045-41d7-42a2-a3c9-9f614f728398/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.